### PR TITLE
Increased timeout

### DIFF
--- a/src/Ftp.h
+++ b/src/Ftp.h
@@ -31,6 +31,7 @@
 #include "Sim800.h"
 #include "Result.h"
 
+
 class FTP : public SIM800
 {
 

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -52,8 +52,8 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
 
   sim800->sendATTest();
 
-  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 10000) != TRUE &&
-          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 10000) != TRUE) &&
+  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 12000) != TRUE &&
+          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 12000) != TRUE) &&
          attempts < MAX_ATTEMPTS)
   {
     sim800->sendCmdAndWaitForResp_P(READ_VOLTAGE, AT_OK, 2000);
@@ -67,20 +67,20 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
     }
   }
 
-  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 12000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 14000) == FALSE)
     result = ERROR_BEARER_PROFILE_GPRS;
 
   char httpApn[64];
   char tmp[24];
   strcpy_P(tmp, apn);
   sprintf_P(httpApn, BEARER_PROFILE_APN, tmp);
-  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 8000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 10000) == FALSE)
     result = ERROR_BEARER_PROFILE_APN;
 
-  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 8000) == FALSE && attempts < MAX_ATTEMPTS)
+  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 10000) == FALSE && attempts < MAX_ATTEMPTS)
   {
     attempts++;
-    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 8000) == FALSE)
+    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 10000) == FALSE)
     {
       result = ERROR_OPEN_GPRS_CONTEXT;
     }

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -52,8 +52,8 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
 
   sim800->sendATTest();
 
-  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 5000) != TRUE &&
-          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 5000) != TRUE) &&
+  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 10000) != TRUE &&
+          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 10000) != TRUE) &&
          attempts < MAX_ATTEMPTS)
   {
     sim800->sendCmdAndWaitForResp_P(READ_VOLTAGE, AT_OK, 2000);
@@ -67,7 +67,7 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
     }
   }
 
-  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 10000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 12000) == FALSE)
     result = ERROR_BEARER_PROFILE_GPRS;
 
   char httpApn[64];
@@ -77,10 +77,10 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
   if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 8000) == FALSE)
     result = ERROR_BEARER_PROFILE_APN;
 
-  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 6000) == FALSE && attempts < MAX_ATTEMPTS)
+  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 8000) == FALSE && attempts < MAX_ATTEMPTS)
   {
     attempts++;
-    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 6000) == FALSE)
+    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 8000) == FALSE)
     {
       result = ERROR_OPEN_GPRS_CONTEXT;
     }

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -52,12 +52,12 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
 
   sim800->sendATTest();
 
-  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 2000) != TRUE &&
-          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 2000) != TRUE) &&
+  while ((sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, CONNECTED, 5000) != TRUE &&
+          sim800->sendCmdAndWaitForResp_P(REGISTRATION_STATUS, ROAMING, 5000) != TRUE) &&
          attempts < MAX_ATTEMPTS)
   {
-    sim800->sendCmdAndWaitForResp_P(READ_VOLTAGE, AT_OK, 1000);
-    sim800->sendCmdAndWaitForResp_P(SIGNAL_QUALITY, AT_OK, 1000);
+    sim800->sendCmdAndWaitForResp_P(READ_VOLTAGE, AT_OK, 2000);
+    sim800->sendCmdAndWaitForResp_P(SIGNAL_QUALITY, AT_OK, 2000);
     attempts++;
     delay(1000 * attempts);
     if (attempts == MAX_ATTEMPTS)
@@ -67,20 +67,20 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
     }
   }
 
-  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 2000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 8000) == FALSE)
     result = ERROR_BEARER_PROFILE_GPRS;
 
   char httpApn[64];
   char tmp[24];
   strcpy_P(tmp, apn);
   sprintf_P(httpApn, BEARER_PROFILE_APN, tmp);
-  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 2000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 6000) == FALSE)
     result = ERROR_BEARER_PROFILE_APN;
 
-  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 2000) == FALSE && attempts < MAX_ATTEMPTS)
+  while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 6000) == FALSE && attempts < MAX_ATTEMPTS)
   {
     attempts++;
-    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 2000) == FALSE)
+    if (sim800->sendCmdAndWaitForResp_P(OPEN_GPRS_CONTEXT, AT_OK, 6000) == FALSE)
     {
       result = ERROR_OPEN_GPRS_CONTEXT;
     }
@@ -97,7 +97,7 @@ Result closeGPRSContext(SIM800 *sim800)
 {
   Result result = SUCCESS;
 
-  if (sim800->sendCmdAndWaitForResp_P(CLOSE_GPRS_CONTEXT, AT_OK, 2000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp_P(CLOSE_GPRS_CONTEXT, AT_OK, 4000) == FALSE)
     result = ERROR_CLOSE_GPRS_CONTEXT;
 
   return result;

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -67,14 +67,14 @@ Result openGPRSContext(SIM800 *sim800, const char *apn)
     }
   }
 
-  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 8000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp_P(BEARER_PROFILE_GPRS, AT_OK, 10000) == FALSE)
     result = ERROR_BEARER_PROFILE_GPRS;
 
   char httpApn[64];
   char tmp[24];
   strcpy_P(tmp, apn);
   sprintf_P(httpApn, BEARER_PROFILE_APN, tmp);
-  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 6000) == FALSE)
+  if (sim800->sendCmdAndWaitForResp(httpApn, AT_OK_, 8000) == FALSE)
     result = ERROR_BEARER_PROFILE_APN;
 
   while (sim800->sendCmdAndWaitForResp_P(QUERY_BEARER, BEARER_OPEN, 6000) == FALSE && attempts < MAX_ATTEMPTS)

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -55,7 +55,7 @@ Result HTTP::connect(const char *apn)
 {
   Result result = openGPRSContext(this, apn);
 
-  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 2000) == FALSE)
+  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 5000) == FALSE)
     result = ERROR_HTTP_INIT;
 
   return result;
@@ -65,7 +65,7 @@ Result HTTP::disconnect()
 {
   Result result = closeGPRSContext(this);
 
-  if (sendCmdAndWaitForResp_P(HTTP_CLOSE, AT_OK, 2000) == FALSE)
+  if (sendCmdAndWaitForResp_P(HTTP_CLOSE, AT_OK, 4000) == FALSE)
     result = ERROR_HTTP_CLOSE;
 
   return result;
@@ -83,7 +83,7 @@ Result HTTP::post(const char *uri, const char *body, char *response)
   sprintf_P(buffer, HTTP_DATA, strlen(body), delayToDownload);
   strcpy_P(resp, DOWNLOAD);
   
-  sendCmdAndWaitForResp(buffer, resp, 2000);
+  sendCmdAndWaitForResp(buffer, resp, 4000);
 
   purgeSerial();
   sendCmd(body);

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -55,7 +55,7 @@ Result HTTP::connect(const char *apn)
 {
   Result result = openGPRSContext(this, apn);
 
-  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 6000) == FALSE)
+  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 8000) == FALSE)
     result = ERROR_HTTP_INIT;
 
   return result;
@@ -83,7 +83,7 @@ Result HTTP::post(const char *uri, const char *body, char *response)
   sprintf_P(buffer, HTTP_DATA, strlen(body), delayToDownload);
   strcpy_P(resp, DOWNLOAD);
   
-  sendCmdAndWaitForResp(buffer, resp, 5000);
+  sendCmdAndWaitForResp(buffer, resp, 7000);
 
   purgeSerial();
   sendCmd(body);
@@ -108,7 +108,7 @@ Result HTTP::get(const char *uri, char *response)
   Result result;
   setHTTPSession(uri);
 
-  if (sendCmdAndWaitForResp_P(HTTP_GET, HTTP_2XX, 2000) == TRUE)
+  if (sendCmdAndWaitForResp_P(HTTP_GET, HTTP_2XX, 7000) == TRUE)
   {
     char buffer[16];
     strcpy_P(buffer, HTTP_READ);

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -55,7 +55,7 @@ Result HTTP::connect(const char *apn)
 {
   Result result = openGPRSContext(this, apn);
 
-  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 5000) == FALSE)
+  if (sendCmdAndWaitForResp_P(HTTP_INIT, AT_OK, 6000) == FALSE)
     result = ERROR_HTTP_INIT;
 
   return result;
@@ -65,7 +65,7 @@ Result HTTP::disconnect()
 {
   Result result = closeGPRSContext(this);
 
-  if (sendCmdAndWaitForResp_P(HTTP_CLOSE, AT_OK, 4000) == FALSE)
+  if (sendCmdAndWaitForResp_P(HTTP_CLOSE, AT_OK, 5000) == FALSE)
     result = ERROR_HTTP_CLOSE;
 
   return result;
@@ -83,7 +83,7 @@ Result HTTP::post(const char *uri, const char *body, char *response)
   sprintf_P(buffer, HTTP_DATA, strlen(body), delayToDownload);
   strcpy_P(resp, DOWNLOAD);
   
-  sendCmdAndWaitForResp(buffer, resp, 4000);
+  sendCmdAndWaitForResp(buffer, resp, 5000);
 
   purgeSerial();
   sendCmd(body);

--- a/src/Sim800.cpp
+++ b/src/Sim800.cpp
@@ -203,11 +203,11 @@ void SIM800::sleep(bool force)
 {
     if (force)
     {
-        sendCmdAndWaitForResp_P(SLEEP_MODE_1, AT_OK, 2000);
+        sendCmdAndWaitForResp_P(SLEEP_MODE_1, AT_OK, 4000);
     }
     else
     {
-        sendCmdAndWaitForResp_P(SLEEP_MODE_2, AT_OK, 2000);
+        sendCmdAndWaitForResp_P(SLEEP_MODE_2, AT_OK, 4000);
     }
 }
 

--- a/src/Sim800.h
+++ b/src/Sim800.h
@@ -37,7 +37,7 @@
 #define DEFAULT_TIMEOUT 5000
 
 // Comment or uncomment this to debug the library
-// #define DEBUG true
+ #define DEBUG true
 
 /** SIM800 class.
  *  Used for SIM800 communication. attention that SIM800 module communicate with MCU in serial protocol

--- a/src/Sim800.h
+++ b/src/Sim800.h
@@ -37,7 +37,7 @@
 #define DEFAULT_TIMEOUT 5000
 
 // Comment or uncomment this to debug the library
- #define DEBUG true
+//#define DEBUG true
 
 /** SIM800 class.
  *  Used for SIM800 communication. attention that SIM800 module communicate with MCU in serial protocol

--- a/src/Sim800.h
+++ b/src/Sim800.h
@@ -37,7 +37,7 @@
 #define DEFAULT_TIMEOUT 5000
 
 // Comment or uncomment this to debug the library
-//#define DEBUG true
+// #define DEBUG true
 
 /** SIM800 class.
  *  Used for SIM800 communication. attention that SIM800 module communicate with MCU in serial protocol


### PR DESCRIPTION
I did a lot of testing these days. It turns out that in some cases connection is lagging quite a bit especially in bad weather. I initially tough that it may be so because of signal quality but it is not always the case. For example i had the station in my room with signal from 10-15 and it was working fine for many days, then i moved it outside where signal was around 20 but i got several errors and command had to be repeated... I tested in all sorts of weather snow,cold, fog, rain, you name it... I had to increase some of the timeouts by quite much but it's now working very well for me....

I was thinking what is the best solution for this? How far to increase the timeout, and how common are these interference in the network. Should we keep shorter timeout and just repeat if failed? Well in my case sometimes i coldn't receive data for several hours with shorter timeout. Then with increased id did work better but if command failed in some cases it had to be repeated for several times before it worked - meaning delay of several minutes. Therefore i rather put longer timeout. Few seconds more make all the difference (no repetition) and i dont see any drawback, since if the code is executed before timeout ends program will proceed further...